### PR TITLE
Fix missing compass install in sencha cmd

### DIFF
--- a/ext/Dockerfile
+++ b/ext/Dockerfile
@@ -40,14 +40,16 @@ RUN echo "Installing Sencha Cmd..." && \
 USER limsuser
 ENV HOME /home/limsuser
 
+COPY resources/cmd-install-responsefile /tmp/cmd-install-responsefile
 RUN wget -O $HOME/cmd-install.run.zip  http://cdn.sencha.com/cmd/${SenchaVersion}/no-jre/SenchaCmd-${SenchaVersion}-linux-amd64.sh.zip && \
     unzip -p $HOME/cmd-install.run.zip > $HOME/cmd-install.run && \
     chmod +x $HOME/cmd-install.run && \
-    INSTALL4J_ADD_VM_PARAMS="-Djava.awt.headless=true" $HOME/cmd-install.run -q && \
+    INSTALL4J_ADD_VM_PARAMS="-Djava.awt.headless=true" $HOME/cmd-install.run -q -varfile /tmp/cmd-install-responsefile && \
     echo "export PATH=$PATH:/home/limsuser/bin/Sencha/Cmd/" >> $HOME/.bash_profile && \
     rm \
         $HOME/cmd-install.run.zip \
         $HOME/cmd-install.run && \
+    chown -R limsuser:limsuser /home/limsuser/bin && \
     echo "DONE"
 
 USER root
@@ -57,5 +59,5 @@ COPY resources/usr/local/bin/dockerlims-shell /usr/local/bin/
 
 WORKDIR /var/www/html/Ext
 
-# NOTE: must use json syntax process is not started in a subshell (and signals are passed correctly)
+# NOTE: must use json syntax to ensure process is not started in a subshell (and signals are passed correctly)
 ENTRYPOINT ["/root/docker-entrypoint.sh"]

--- a/ext/resources/cmd-install-responsefile
+++ b/ext/resources/cmd-install-responsefile
@@ -1,0 +1,11 @@
+sys.adminRights$Boolean=true
+sys.component.148$Boolean=true
+sys.component.157$Boolean=true
+sys.component.26$Boolean=true
+sys.component.30$Boolean=true
+sys.component.90$Boolean=true
+sys.component.91$Boolean=true
+sys.component.92$Boolean=true
+sys.component.94$Boolean=true
+sys.installationDir=/home/limsuser/bin/Sencha/Cmd/6.2.2.36
+sys.languageId=en


### PR DESCRIPTION
By default, compass isn't enabled when you install cmd, which causes builds to fail when run from the Docker container. 

I eventually discovered the trick of specifying the responsefile from: https://www.sencha.com/forum/showthread.php?303323-Installing-Sencha-CMD-6-silently-with-the-compass-extension&p=1116904&viewfull=1#post1116904

The suggestion on the above thread to use -a or --all did not work for me